### PR TITLE
Fix crash when starting from non ASCII path

### DIFF
--- a/Universal Tomb Launcher/Configuration.cs
+++ b/Universal Tomb Launcher/Configuration.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Xml.Serialization;
 using UniversalTombLauncher.Enums;
+using UniversalTombLauncher.Native;
 
 namespace UniversalTombLauncher
 {

--- a/Universal Tomb Launcher/Helpers/InputHelper.cs
+++ b/Universal Tomb Launcher/Helpers/InputHelper.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using UniversalTombLauncher.Native;
 
 namespace UniversalTombLauncher.Helpers
 {

--- a/Universal Tomb Launcher/Helpers/ProcessHelper.cs
+++ b/Universal Tomb Launcher/Helpers/ProcessHelper.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using UniversalTombLauncher.Enums;
+using UniversalTombLauncher.Native;
 
 namespace UniversalTombLauncher.Helpers
 {

--- a/Universal Tomb Launcher/Helpers/ShellHelper.cs
+++ b/Universal Tomb Launcher/Helpers/ShellHelper.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.IO;
 using System.Runtime.InteropServices.ComTypes;
-using System.Text;
+using UniversalTombLauncher.Native;
 
 namespace UniversalTombLauncher.Helpers
 {
@@ -11,50 +8,23 @@ namespace UniversalTombLauncher.Helpers
 	{
 		public static IPersistFile CreateShortcutWithIcon(string exeFilePath, string iconLocation, string args)
 		{
-			IShellLink link = (IShellLink)new ShellLink();
+			var link = (IShellLink)new ShellLink();
+
 			link.SetPath(exeFilePath);
 			link.SetWorkingDirectory(Path.GetDirectoryName(exeFilePath));
 			link.SetIconLocation(iconLocation, 0);
 			link.SetArguments(args);
+
 			return (IPersistFile)link;
 		}
 
 		public static string SaveShortcut(IPersistFile shortcut, string exeFilePath)
 		{
-			string shortcutPath = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(exeFilePath) + ".lnk");
+			string exeFileName = Path.GetFileNameWithoutExtension(exeFilePath);
+			string shortcutPath = Path.Combine(Path.GetTempPath(), exeFileName + ".lnk");
+
 			shortcut.Save(shortcutPath, false);
 			return shortcutPath;
 		}
-	}
-
-	[ComImport]
-	[Guid("00021401-0000-0000-C000-000000000046")]
-	internal class ShellLink
-	{
-	}
-
-	[ComImport]
-	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-	[Guid("000214F9-0000-0000-C000-000000000046")]
-	internal interface IShellLink
-	{
-		void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, out IntPtr pfd, int fFlags);
-		void GetIDList(out IntPtr ppidl);
-		void SetIDList(IntPtr pidl);
-		void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
-		void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-		void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
-		void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-		void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
-		void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
-		void GetHotkey(out short pwHotkey);
-		void SetHotkey(short wHotkey);
-		void GetShowCmd(out int piShowCmd);
-		void SetShowCmd(int iShowCmd);
-		void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
-		void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
-		void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
-		void Resolve(IntPtr hwnd, int fFlags);
-		void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
 	}
 }

--- a/Universal Tomb Launcher/Helpers/ShellHelper.cs
+++ b/Universal Tomb Launcher/Helpers/ShellHelper.cs
@@ -1,23 +1,60 @@
-﻿using IWshRuntimeLibrary;
+﻿using System;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
 
 namespace UniversalTombLauncher.Helpers
 {
 	internal static class ShellHelper
 	{
-		public static IWshShortcut CreateShortcutWithIcon(string exeFilePath, string iconLocation)
+		public static IPersistFile CreateShortcutWithIcon(string exeFilePath, string iconLocation, string args)
 		{
-			string fileName = Path.GetFileNameWithoutExtension(exeFilePath);
-
-			var shell = new WshShell();
-			string shortcutPath = Path.Combine(Path.GetTempPath(), fileName + ".lnk");
-
-			var shortcut = (IWshShortcut)shell.CreateShortcut(shortcutPath);
-			shortcut.TargetPath = exeFilePath;
-			shortcut.WorkingDirectory = Path.GetDirectoryName(exeFilePath);
-			shortcut.IconLocation = iconLocation;
-
-			return shortcut;
+			IShellLink link = (IShellLink)new ShellLink();
+			link.SetPath(exeFilePath);
+			link.SetWorkingDirectory(Path.GetDirectoryName(exeFilePath));
+			link.SetIconLocation(iconLocation, 0);
+			link.SetArguments(args);
+			return (IPersistFile)link;
 		}
+
+		public static string SaveShortcut(IPersistFile shortcut, string exeFilePath)
+		{
+			string shortcutPath = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(exeFilePath) + ".lnk");
+			shortcut.Save(shortcutPath, false);
+			return shortcutPath;
+		}
+	}
+
+	[ComImport]
+	[Guid("00021401-0000-0000-C000-000000000046")]
+	internal class ShellLink
+	{
+	}
+
+	[ComImport]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[Guid("000214F9-0000-0000-C000-000000000046")]
+	internal interface IShellLink
+	{
+		void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, out IntPtr pfd, int fFlags);
+		void GetIDList(out IntPtr ppidl);
+		void SetIDList(IntPtr pidl);
+		void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
+		void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+		void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
+		void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+		void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
+		void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+		void GetHotkey(out short pwHotkey);
+		void SetHotkey(short wHotkey);
+		void GetShowCmd(out int piShowCmd);
+		void SetShowCmd(int iShowCmd);
+		void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
+		void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+		void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
+		void Resolve(IntPtr hwnd, int fFlags);
+		void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
 	}
 }

--- a/Universal Tomb Launcher/Native/NativeClasses.cs
+++ b/Universal Tomb Launcher/Native/NativeClasses.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace UniversalTombLauncher.Native
+{
+	[ComImport]
+	[Guid("00021401-0000-0000-C000-000000000046")]
+	internal class ShellLink
+	{ }
+}

--- a/Universal Tomb Launcher/Native/NativeEnums.cs
+++ b/Universal Tomb Launcher/Native/NativeEnums.cs
@@ -1,4 +1,4 @@
-﻿namespace UniversalTombLauncher
+﻿namespace UniversalTombLauncher.Native
 {
 	public enum WCA
 	{

--- a/Universal Tomb Launcher/Native/NativeInterfaces.cs
+++ b/Universal Tomb Launcher/Native/NativeInterfaces.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace UniversalTombLauncher.Native
+{
+	[ComImport]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	[Guid("000214F9-0000-0000-C000-000000000046")]
+	internal interface IShellLink
+	{
+		void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, out IntPtr pfd, int fFlags);
+		void GetIDList(out IntPtr ppidl);
+		void SetIDList(IntPtr pidl);
+		void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
+		void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+		void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
+		void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+		void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
+		void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+		void GetHotkey(out short pwHotkey);
+		void SetHotkey(short wHotkey);
+		void GetShowCmd(out int piShowCmd);
+		void SetShowCmd(int iShowCmd);
+		void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
+		void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+		void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
+		void Resolve(IntPtr hwnd, int fFlags);
+		void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+	}
+}

--- a/Universal Tomb Launcher/Native/NativeMethods.cs
+++ b/Universal Tomb Launcher/Native/NativeMethods.cs
@@ -2,7 +2,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 
-namespace UniversalTombLauncher
+namespace UniversalTombLauncher.Native
 {
 	internal static class NativeMethods
 	{

--- a/Universal Tomb Launcher/Native/NativeStructs.cs
+++ b/Universal Tomb Launcher/Native/NativeStructs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace UniversalTombLauncher
+namespace UniversalTombLauncher.Native
 {
 	internal struct INPUT
 	{

--- a/Universal Tomb Launcher/Program.cs
+++ b/Universal Tomb Launcher/Program.cs
@@ -125,7 +125,6 @@ namespace UniversalTombLauncher
 		{
 			string iconLocation = Assembly.GetExecutingAssembly().Location; // Target icon is the icon of this launcher
 
-			var shortcut = ShellHelper.CreateShortcutWithIcon(exeFilePath, iconLocation);
 			var argumentsBuilder = new StringBuilder();
 
 			if (setup)
@@ -134,10 +133,8 @@ namespace UniversalTombLauncher
 			if (debug)
 				argumentsBuilder.Append("-debug ");
 
-			shortcut.Arguments = argumentsBuilder.ToString();
-			shortcut.Save();
-
-			return shortcut.FullName;
+			var shortcut = ShellHelper.CreateShortcutWithIcon(exeFilePath, iconLocation, argumentsBuilder.ToString());
+			return ShellHelper.SaveShortcut(shortcut, exeFilePath);
 		}
 	}
 }

--- a/Universal Tomb Launcher/Universal Tomb Launcher.csproj
+++ b/Universal Tomb Launcher/Universal Tomb Launcher.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -78,17 +79,6 @@
     <Compile Include="NativeStructs.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <COMReference Include="IWshRuntimeLibrary">
-      <Guid>{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Forms\FormExtraSettings.resx">

--- a/Universal Tomb Launcher/Universal Tomb Launcher.csproj
+++ b/Universal Tomb Launcher/Universal Tomb Launcher.csproj
@@ -11,7 +11,6 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -65,7 +64,9 @@
     <Compile Include="Helpers\FileHelper.cs" />
     <Compile Include="Helpers\InputHelper.cs" />
     <Compile Include="Helpers\OSVersionHelper.cs" />
-    <Compile Include="NativeEnums.cs" />
+    <Compile Include="Native\NativeClasses.cs" />
+    <Compile Include="Native\NativeEnums.cs" />
+    <Compile Include="Native\NativeInterfaces.cs" />
     <Compile Include="Utils\FullscreenBorderFix.cs" />
     <Compile Include="Utils\LogCleaner.cs" />
     <Compile Include="Helpers\ProcessHelper.cs" />
@@ -75,8 +76,8 @@
     <Compile Include="Controls\HighQualityLabel.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="NativeMethods.cs" />
-    <Compile Include="NativeStructs.cs" />
+    <Compile Include="Native\NativeMethods.cs" />
+    <Compile Include="Native\NativeStructs.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Universal Tomb Launcher/Utils/WindowUtils.cs
+++ b/Universal Tomb Launcher/Utils/WindowUtils.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using UniversalTombLauncher.Native;
 
 namespace UniversalTombLauncher.Utils
 {


### PR DESCRIPTION
This fixes a crash that occurs when the launcher is started from a folder whose absolute path does contain non ASCII characters. This was due to the use of the WshRuntimeLibrary (a wrapper around COM libraries) that does not handle Unicode (as far as my deductions go). When assigning the target path to the shortcut object, the runtime would error.

This commit replaces the WshRuntimeLibrary with a COM wrapper around the IShellLink interface, using its Unicode oriented functions.

The WshRuntimeLibrary is removed from dependencies and the .NET framework is updated to 4.8 as 4.0 has reached EOL.

Tested on: Win10 64-bits.

**Warning:** The code is taken from https://stackoverflow.com/a/14632782 As you can see from the comments, some people argue this does not work on all versions of Windows, possibly something tied to 32 / 64 bits. Further testing on other Win versions and archs is probably required